### PR TITLE
Showing multiline Request and Response Messages

### DIFF
--- a/Src/ShowRequestMessageMethWLD.Codeunit.al
+++ b/Src/ShowRequestMessageMethWLD.Codeunit.al
@@ -15,13 +15,28 @@ codeunit 79912 "ShowRequestMessage Meth WLD"
     var
         Instr: Instream;
         RequestMessage: Text;
+        TempText: Text;
+        CRLF: Text[2];
     begin
+
         if Handled then
             exit;
 
+        CRLF[1] := 13;
+        CRLF[2] := 10;
+
         log.CalcFields(RequestBody);
         log.RequestBody.CreateInStream(Instr);
-        Instr.ReadText(RequestMessage);
+        // Instr.ReadText(RequestMessage);
+
+        //show only 50,000 line
+        while (not Instr.EOS) and (StrLen(RequestMessage) < 50000) do begin
+            Instr.ReadText(TempText);
+            if (strlen(RequestMessage) > 0) then
+                RequestMessage := RequestMessage + CRLF + TempText
+            else
+                RequestMessage := TempText;
+        end;
 
         Message(RequestMessage);
     end;

--- a/Src/ShowResponseMessageMethWLD.Codeunit.al
+++ b/Src/ShowResponseMessageMethWLD.Codeunit.al
@@ -14,16 +14,32 @@ codeunit 79913 "ShowResponseMessage Meth WLD"
     local procedure DoShowResponseMessage(var Log: Record "REST Log WLD"; var Handled: Boolean);
     var
         Instr: Instream;
-        RequestMessage: Text;
+        ResponseMessage: Text;
+        TempText: Text;
+        CRLF: Text[2];
     begin
+
         if Handled then
             exit;
 
+        CRLF[1] := 13;
+        CRLF[2] := 10;
+
         log.CalcFields(Response);
         log.Response.CreateInStream(Instr);
-        Instr.ReadText(RequestMessage);
+        // Instr.ReadText(RequestMessage);
 
-        Message(RequestMessage);
+        //show only 50,000 line
+        while (not Instr.EOS) and (StrLen(ResponseMessage) < 50000) do begin
+            Instr.ReadText(TempText);
+            if (strlen(ResponseMessage) > 0) then
+                ResponseMessage := ResponseMessage + CRLF + TempText
+            else
+                ResponseMessage := TempText;
+        end;
+
+
+        Message(ResponseMessage);
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
in case theres multiple lines in Request and Response Message, show them all(50,000) in the Message, instead of the first line